### PR TITLE
delay neutral gear to prevent flashing during shifts

### DIFF
--- a/tools/ac.py
+++ b/tools/ac.py
@@ -91,7 +91,7 @@ class AcClient(fanatec_led_server.Client):
                 else:
                     self.revmax = 4000
                     self.autorpm = 1
-                    print("Car '%s' not found in car_data! Setting max revs to %i. Rev the car into the limiter while in neutral to adjust. After max RPM has reached it saves the value." % (car_name, self.revmax))
+                    print("Car '%s' not found in car_data! Setting max revs to %i. Rev the car into the limiter while in neutral to adjust." % (car_name, self.revmax))
 
             # confirm
             AcClient.client_data(self.sock, AcClient.SUBSCRIBE_UPDATE)

--- a/tools/ac.py
+++ b/tools/ac.py
@@ -37,6 +37,7 @@ class AcClient(fanatec_led_server.Client):
         self._gear = 0
         self.autorpm = 0
         self.revsavetimer = None
+        self.car_name = None
 
     @staticmethod
     def client_data(sock, operation):
@@ -81,6 +82,7 @@ class AcClient(fanatec_led_server.Client):
                 .strip("\x00")
                 .replace("\x00", "")
             )[:-1]
+            self.car_name = car_name
             # print("Car name:", car_name)
             # breakpoint()
             if self.revmax is None:
@@ -140,7 +142,11 @@ class AcClient(fanatec_led_server.Client):
         if self.revsavetimer != None and ((datetime.datetime.now().minute * 60)  + datetime.datetime.now().second)  - ((self.revsavetimer.minute * 60 ) + self.revsavetimer.second) >= 3:
             self.autorpm = 0
             self.revsavetimer = None
-            print("RPM adjusted to %i"%(self.revmax))
+            print("revlimiter adjusted to %i"%(self.revmax))
+            car_data[self.car_name] = "%i"%(self.revmax)
+            with open("car_data.json", "w") as write_file:
+                json.dump(car_data, write_file, indent=4)
+            print("revlimit saved to database")
 
         self._gear = int.from_bytes(data[76:80], byteorder="little") - 1
         return True

--- a/tools/car_data.json
+++ b/tools/car_data.json
@@ -1,4 +1,5 @@
-{"lotus_elise_sc_s2": "8500",
+{
+    "lotus_elise_sc_s2": "8500",
     "ks_porsche_911_gt3_r_2016": "9000",
     "ks_corvette_c7r": "7000",
     "bmw_z4_s1": "7200",
@@ -16,14 +17,16 @@
     "ks_mclaren_570s": "8500",
     "ks_mazda_rx7_spirit_r": "8500",
     "ks_mercedes_190_evo2": "9750",
-    "tatuusfa1": "6500", "pagani_huayra":
-    "7000", "mclaren_mp412c": "8500",
+    "tatuusfa1": "6500",
+    "pagani_huayra": "7000",
+    "mclaren_mp412c": "8500",
     "ks_ferrari_488_gtb": "8250",
     "ks_toyota_supra_mkiv_drift": "8000",
     "ks_ferrari_sf15t": "17000",
-    "lotus_evora_gte": "7600", "bmw_z4":
-    "7200", "ks_corvette_c7_stingray":
-    "9000", "ruf_yellowbird": "7000",
+    "lotus_evora_gte": "7600",
+    "bmw_z4": "7200",
+    "ks_corvette_c7_stingray": "9000",
+    "ruf_yellowbird": "7000",
     "ks_ford_gt40": "8000",
     "ks_lamborghini_gallardo_sl": "8000",
     "ks_toyota_ts040": "8000",
@@ -42,25 +45,24 @@
     "lotus_evora_gte_carbon": "7600",
     "ks_lamborghini_huracan_gt3": "9250",
     "bmw_z4_gt3": "8750",
-    "ks_porsche_935_78_moby_dick":
-    "9500", "lotus_98t": "12500",
+    "ks_porsche_935_78_moby_dick": "9500",
+    "lotus_98t": "12500",
     "ks_alfa_giulia_qv": "7400",
     "ks_porsche_918_spyder": "9150",
     "ks_porsche_718_boxster_s": "8000",
     "ks_mclaren_650_gt3": "7500",
     "bmw_1m_s3": "7250",
-    "ks_porsche_718_boxster_s_pdk":
-    "8000", "ks_maserati_quattroporte":
-    "7500", "shelby_cobra_427sc": "7000",
+    "ks_porsche_718_boxster_s_pdk": "8000",
+    "ks_maserati_quattroporte": "7500",
+    "shelby_cobra_427sc": "7000",
     "ks_nissan_skyline_r34": "8000",
     "bmw_1m": "7200",
     "ks_ford_mustang_2015": "7500",
     "ks_maserati_mc12_gt1": "8000",
     "ks_lamborghini_countach_s1": "8000",
-    "ks_porsche_cayman_gt4_clubsport":
-    "8300",
-    "ks_audi_sport_quattro_rally":
-    "8750", "lotus_evora_s_s2": "7600",
+    "ks_porsche_cayman_gt4_clubsport": "8300",
+    "ks_audi_sport_quattro_rally": "8750",
+    "lotus_evora_s_s2": "7600",
     "ks_porsche_962c_longtail": "8500",
     "ferrari_458_s3": "9000",
     "ks_porsche_991_turbo_s": "7500",
@@ -76,8 +78,8 @@
     "ks_audi_sport_quattro": "7250",
     "ks_alfa_romeo_gta": "8500",
     "ks_lotus_25": "10000",
-    "ks_porsche_911_gt3_cup_2017":
-    "8500", "ks_audi_r8_plus": "9250",
+    "ks_porsche_911_gt3_cup_2017": "8500",
+    "ks_audi_r8_plus": "9250",
     "ks_lamborghini_countach": "8000",
     "lotus_exige_240_s3": "8500",
     "bmw_m3_e30_s1": "7250",
@@ -95,9 +97,9 @@
     "ks_toyota_ae86_tuned": "9500",
     "lotus_exos_125": "11000",
     "ks_ferrari_fxx_k": "9500",
-    "ks_lamborghini_sesto_elemento":
-    "9250", "ks_bmw_m4_akrapovic":
-    "8000", "abarth500": "6500",
+    "ks_lamborghini_sesto_elemento": "9250",
+    "ks_bmw_m4_akrapovic": "8000",
+    "abarth500": "6500",
     "ks_lotus_3_eleven": "8000",
     "ks_mclaren_p1_gtr": "9000",
     "lotus_evora_gtc": "7200",
@@ -114,9 +116,10 @@
     "ks_lamborghini_miura_sv": "8500",
     "ks_porsche_917_k": "9000",
     "ks_bmw_m235i_racing": "7200",
-    "ks_bmw_m4": "8000", "ferrari_458":
-    "9000", "ks_abarth500_assetto_corse":
-    "7500", "ks_ferrari_488_gt3": "8250",
+    "ks_bmw_m4": "8000",
+    "ferrari_458": "9000",
+    "ks_abarth500_assetto_corse": "7500",
+    "ks_ferrari_488_gt3": "8250",
     "ks_porsche_919_hybrid_2015": "8000",
     "ks_porsche_macan": "7000",
     "lotus_exige_scura": "8500",
@@ -125,10 +128,12 @@
     "bmw_m3_e30_gra": "8500",
     "ks_maserati_250f_12cyl": "11000",
     "ks_lamborghini_huracan_st": "8000",
-    "p4-5_2011": "8250", "bmw_m3_gt2":
-    "8750", "ks_ruf_rt12r_awd": "8000",
-    "lotus_2_eleven": "8500", "lotus_49":
-    "10000", "ferrari_458_gt2": "8750",
+    "p4-5_2011": "8250",
+    "bmw_m3_gt2": "8750",
+    "ks_ruf_rt12r_awd": "8000",
+    "lotus_2_eleven": "8500",
+    "lotus_49": "10000",
+    "ferrari_458_gt2": "8750",
     "ks_lotus_72d": "12000",
     "ks_mazda_miata": "7500",
     "ks_praga_r1": "8500",
@@ -156,18 +161,20 @@
     "ks_pagani_huayra_bc": "8000",
     "ks_mclaren_p1": "8250",
     "lotus_exige_240": "8500",
-    "ks_lamborghini_huracan_performante":
-    "9250", "mclaren_mp412c_gt3": "7500",
+    "ks_lamborghini_huracan_performante": "9250",
+    "mclaren_mp412c_gt3": "7500",
     "ks_toyota_celica_st185": "7500",
     "ks_glickenhaus_scg003": "7250",
     "ks_ferrari_330_p4": "9000",
     "lotus_evora_gx": "7200",
-    "ks_lamborghini_aventador_sv":
-    "9000", "ks_audi_sport_quattro_s1":
-    "7250", "ks_ruf_rt12r": "8000",
+    "ks_lamborghini_aventador_sv": "9000",
+    "ks_audi_sport_quattro_s1": "7250",
+    "ks_ruf_rt12r": "8000",
     "ks_alfa_33_stradale": "10500",
     "lotus_exige_s_roadster": "7500",
     "ks_mazda_rx7_tuned": "9500",
     "ks_porsche_911_r": "9000",
     "ks_audi_r18_etron_quattro": "8000",
-    "ks_toyota_ae86": "8500"}
+    "ks_toyota_ae86": "8500",
+    "callaway_corvette_c7_gt3": "8057"
+}

--- a/tools/fanatec_led_server.py
+++ b/tools/fanatec_led_server.py
@@ -11,7 +11,6 @@ import fanatec_input
 LEDS = 9
 
 
-
 def set_leds(values):
     global wheel
     wheel.RPM = values
@@ -183,7 +182,7 @@ class Client(threading.Thread):
                         if self.wheel == fanatec_input.CSLEliteWheel:
                             gear = {-1: "R", 0: "N"}
                         elif self.wheel == fanatec_input.CSLP1V2Wheel:
-                            gear = {-1: "r", 0: "n"}
+                            gear = {-1: "-1", 0: "000"}
 
                         if self.gear != 0:
                             lastgear = self.gear
@@ -195,15 +194,13 @@ class Client(threading.Thread):
 
                             else:
                                 dt = datetime.datetime.now()
-                                if ((dt.minute * 60000000) + (dt.second * 1000000) + dt.microsecond) - ((neutral_timer.minute * 60000000) + (neutral_timer.second * 1000000) + neutral_timer.microsecond) >= 350000:
+                                if int(str(dt.minute).rjust(2,'0') + str(dt.second).rjust(2, '0') + str(dt.microsecond)) - int(str(neutral_timer.minute).rjust(2, '0') + str(neutral_timer.second).rjust(2, '0') + str(neutral_timer.microsecond)) >= 350000:
                                     lastgear = 0
 
 
                         display_val = (
                             gear[lastgear] if lastgear in gear else str(lastgear)
                         )
-
-
                         # print(display_val)
                     open(display, "w").write(display_val)
 

--- a/tools/fanatec_led_server.py
+++ b/tools/fanatec_led_server.py
@@ -11,6 +11,7 @@ import fanatec_input
 LEDS = 9
 
 
+
 def set_leds(values):
     global wheel
     wheel.RPM = values
@@ -182,7 +183,7 @@ class Client(threading.Thread):
                         if self.wheel == fanatec_input.CSLEliteWheel:
                             gear = {-1: "R", 0: "N"}
                         elif self.wheel == fanatec_input.CSLP1V2Wheel:
-                            gear = {-1: "-1", 0: "000"}
+                            gear = {-1: "r", 0: "n"}
 
                         if self.gear != 0:
                             lastgear = self.gear
@@ -194,13 +195,15 @@ class Client(threading.Thread):
 
                             else:
                                 dt = datetime.datetime.now()
-                                if int(str(dt.minute).rjust(2,'0') + str(dt.second).rjust(2, '0') + str(dt.microsecond)) - int(str(neutral_timer.minute).rjust(2, '0') + str(neutral_timer.second).rjust(2, '0') + str(neutral_timer.microsecond)) >= 350000:
+                                if ((dt.minute * 60000000) + (dt.second * 1000000) + dt.microsecond) - ((neutral_timer.minute * 60000000) + (neutral_timer.second * 1000000) + neutral_timer.microsecond) >= 350000:
                                     lastgear = 0
 
 
                         display_val = (
                             gear[lastgear] if lastgear in gear else str(lastgear)
                         )
+
+
                         # print(display_val)
                     open(display, "w").write(display_val)
 

--- a/tools/fanatec_led_server.py
+++ b/tools/fanatec_led_server.py
@@ -3,6 +3,7 @@ import sys
 import os
 import time
 import threading
+import datetime
 
 sys.path.append("../dbus")
 import fanatec_input
@@ -149,6 +150,8 @@ class Client(threading.Thread):
             print(self, "connected")
 
         rpms_maxed = 0
+        lastgear = 0
+        neutral_timer = None
         while not self.ev.isSet():
             if not self.tick():
                 break
@@ -180,10 +183,24 @@ class Client(threading.Thread):
                             gear = {-1: "R", 0: "N"}
                         elif self.wheel == fanatec_input.CSLP1V2Wheel:
                             gear = {-1: "-1", 0: "000"}
-                        display_val = (
-                            gear[self.gear] if self.gear in gear else str(self.gear)
-                        )
 
+                        if self.gear != 0:
+                            lastgear = self.gear
+                            neutral_timer = None
+
+                        elif self.gear == 0:
+                            if neutral_timer == None:
+                                neutral_timer = datetime.datetime.now()
+
+                            else:
+                                dt = datetime.datetime.now()
+                                if int(str(dt.minute).rjust(2,'0') + str(dt.second).rjust(2, '0') + str(dt.microsecond)) - int(str(neutral_timer.minute).rjust(2, '0') + str(neutral_timer.second).rjust(2, '0') + str(neutral_timer.microsecond)) >= 350000:
+                                    lastgear = 0
+
+
+                        display_val = (
+                            gear[lastgear] if lastgear in gear else str(lastgear)
+                        )
                         # print(display_val)
                     open(display, "w").write(display_val)
 

--- a/tools/fanatec_led_server.py
+++ b/tools/fanatec_led_server.py
@@ -194,7 +194,7 @@ class Client(threading.Thread):
 
                             else:
                                 dt = datetime.datetime.now()
-                                if int(str(dt.minute).rjust(2,'0') + str(dt.second).rjust(2, '0') + str(dt.microsecond)) - int(str(neutral_timer.minute).rjust(2, '0') + str(neutral_timer.second).rjust(2, '0') + str(neutral_timer.microsecond)) >= 350000:
+                                if ((dt.minute * 60000000) + (dt.second * 1000000) + dt.microsecond) - ((neutral_timer.minute * 60000000) + (neutral_timer.second * 1000000) + neutral_timer.microsecond) >= 350000:
                                     lastgear = 0
 
 


### PR DESCRIPTION
delays outputting the neutral gear to the display i tiny bit to prevent the neutral gear to be displayed during up/downshifts in semiautomatic shifting cars. doesnt affect other gears.  + revlimit detection in ac if car is unknown