### PR TITLE
Added F1 2020 Wheel support and fix issue, with picking the wrong device folder

### DIFF
--- a/dbus/fanatec_input.py
+++ b/dbus/fanatec_input.py
@@ -24,6 +24,7 @@ CSR_ELITE_WHEELBASE_DEVICE_ID = "0011"
 CSL_STEERING_WHEEL_P1_V2 = "08"
 CSL_ELITE_STEERING_WHEEL_WRC_ID = "04"
 CSL_ELITE_STEERING_WHEEL_MCLAREN_GT3_V2_ID = "0b"
+CLUBSPORT_STEERING_WHEEL_F1_2020 = "2e"
 CLUBSPORT_STEERING_WHEEL_F1_IS_ID = "21"
 CLUBSPORT_STEERING_WHEEL_FORMULA_V2_ID = "0a"
 PODIUM_STEERING_WHEEL_PORSCHE_911_GT3_R_ID = "0c"
@@ -37,6 +38,11 @@ def get_sysfs_base(PID):
     sysfs = glob.glob(sysfs_pattern)
     if len(sysfs) == 0:
         raise Exception("Device with PID=%s not found (%s)" % (PID, sysfs_pattern))
+
+    for s in sysfs:
+        wheel_id = os.path.join(s, "wheel_id")
+        if os.path.isfile(wheel_id):
+            return s
     return sysfs[0]
 
 

--- a/dbus/fanatec_input.py
+++ b/dbus/fanatec_input.py
@@ -43,7 +43,7 @@ def get_sysfs_base(PID):
         wheel_id = os.path.join(s, "wheel_id")
         if os.path.isfile(wheel_id):
             return s
-    return sysfs[0]
+    raise Exception(f'Failed to detect the wheel_id. Please check, if the device with PID={PID} has a wheel_id file. Searched directories: {sysfs}')
 
 
 class FanatecWheelBase(object):

--- a/tools/fanatec_led_server.py
+++ b/tools/fanatec_led_server.py
@@ -35,6 +35,7 @@ wheels_dict = {
     fanatec_input.CSL_STEERING_WHEEL_P1_V2: fanatec_input.CSLP1V2Wheel,
     fanatec_input.CSL_ELITE_STEERING_WHEEL_WRC_ID: fanatec_input.CSLP1V2Wheel,
     fanatec_input.CLUBSPORT_STEERING_WHEEL_F1_IS_ID: fanatec_input.CSLEliteWheel,
+    fanatec_input.CLUBSPORT_STEERING_WHEEL_F1_2020: fanatec_input.CSLEliteWheel,
 }
 
 


### PR DESCRIPTION
added: Wheel F1 2020 support
fixed: Pick the correct device (the one with wheel_id), when there is more that one with the same PID

With the new driver with hidraw support the wheel has two devices. This fix makes sure, that it pickes the one with the wheel_id.

My devices look like this:
```
ls  0003:0EB7:0006.0013/
country  display  driver  ftec_tuning  input  leds  modalias  power  range  report_descriptor  subsystem  uevent  wheel_id

ls  0003:0EB7:0006.0014/
country  driver  hidraw  modalias  power  report_descriptor  subsystem  uevent
```