### PR TITLE
Add basic script to quickly turn off CSLP1V2 revstripe/light.

### DIFF
--- a/tools/utilities.py
+++ b/tools/utilities.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python3
+
+import sys
+
+sys.path.append("../dbus")
+import fanatec_input
+
+def turn_off_light() :
+    "The fanatec_input module provides the CSLP1V2Wheel class for controlling the RevStripe™© on equipped models. This function is a quick hack to turn the stripe off without modifying the driver itself."
+
+    wheel = fanatec_input.CSLP1V2Wheel()
+
+    wheel.set_sysfs_rpm(99)
+    wheel.set_sysfs_rpm(0)
+
+if __name__ == "__main__" :
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Random utilities for Fanatec wheels"
+    )
+    parser.add_argument(
+        '-l', '--turn_off_light',
+        action='store_true',
+        help="Attempt to disable RevStripe for, e.g., CSL WRC wheel so it's not shining in your face.")
+    args = parser.parse_args()
+
+    if args.turn_off_light :
+        turn_off_light()

--- a/tools/utilities.py
+++ b/tools/utilities.py
@@ -5,15 +5,19 @@ import sys
 sys.path.append("../dbus")
 import fanatec_input
 
-def turn_off_light() :
-    "The fanatec_input module provides the CSLP1V2Wheel class for controlling the RevStripe™© on equipped models. This function is a quick hack to turn the stripe off without modifying the driver itself."
+
+def turn_off_light():
+    """The fanatec_input module provides the CSLP1V2Wheel class for controlling
+    the RevStripe™© on equipped models. This function is a quick hack to turn
+    the stripe off without modifying the driver itself."""
 
     wheel = fanatec_input.CSLP1V2Wheel()
 
     wheel.set_sysfs_rpm(99)
     wheel.set_sysfs_rpm(0)
 
-if __name__ == "__main__" :
+
+if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(
@@ -22,10 +26,11 @@ if __name__ == "__main__" :
     parser.add_argument(
         '-l', '--turn_off_light',
         action='store_true',
-        help="Attempt to disable RevStripe for, e.g., CSL WRC wheel so it's not shining in your face.")
+        help="Attempt to disable RevStripe for, e.g., CSL WRC wheel so it's \
+        not shining in your face.")
     args = parser.parse_args()
 
-    if args.turn_off_light :
+    if args.turn_off_light:
         turn_off_light()
-    else :
+    else:
         parser.print_help()

--- a/tools/utilities.py
+++ b/tools/utilities.py
@@ -27,3 +27,5 @@ if __name__ == "__main__" :
 
     if args.turn_off_light :
         turn_off_light()
+    else :
+        parser.print_help()


### PR DESCRIPTION
On my Fanatec CSL Elite WRC wheel, the 'revstripe' light at the top of the wheel defaults to being turned on and green, which is annoying because it's very bright.  This `utilities.py` script just uses the CSLP1V2 class in `fanatec_input.py` to manually set the RPM to 99% then zero, which turns the light off, when run with `-l`.

I figure this is *technically* a bug with the driver as the revstripe defaults to off on Windows, so I'll probably open an issue there too.  I sadly don't have the experience or balls to mess around with driver code, so I figured I'd offer a "solution" I use instead of only complaining, lol.